### PR TITLE
Support envoy 1.17's v3 api properly

### DIFF
--- a/Dockerfile-service
+++ b/Dockerfile-service
@@ -1,7 +1,7 @@
 ARG ENVOY
 FROM envoyproxy/envoy-alpine:$ENVOY
 
-RUN apk update && apk add python3 py-pip bash
+RUN apk update && apk add python3 py-pip bash curl
 RUN python3 --version && pip3 --version
 RUN pip3 install -q Flask==0.11.1 requests==2.18.4
 RUN mkdir /code

--- a/Dockerfile-sigsci-agent-grpc-alpine
+++ b/Dockerfile-sigsci-agent-grpc-alpine
@@ -1,0 +1,6 @@
+# Same as Dockerfile-sigsci-agent-grpc, but using sigsci's preconfigured Alpine linux container.
+FROM signalsciences/sigsci-agent:latest
+#FROM sigsci-agent-dev
+USER root
+RUN mkdir /etc/sigsci
+COPY agent.conf /etc/sigsci/agent.conf

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,27 @@
 # Which versions of sigsci-agent and Envoy to use
 # For Sigsci, pick from https://docs.signalsciences.net/release/agent/
 # For Envoy, pick from https://hub.docker.com/r/envoyproxy/envoy-alpine/tags
-#
-## Combinations that pass the "make check" smoke test:
+# Leave all but the combination of interest commented out
+
+#---------- Envoy V3 ---------
+# Envoy 1.17 and up use the v3 api, so give it the -v3.yaml example files.
 ## 2021 Jan
-# Envoy 1.17 disabled the v2 api used by the demo.
-# To get this to work properly, we'll need to update the yaml and the agent.
-# Until then, we can force v2 back on temporarily by passing --bootstrap-version 2, per
-# https://www.envoyproxy.io/docs/envoy/latest/faq/api/transition
-SIGSCI=4.15.0
+ENVOYARGS=
+APISUFFIX=-v3
+SIGSCI=4.16.0
 ENVOY=v1.17.0
-ENVOYARGS=--bootstrap-version 2
+
+#---------- Envoy V2, forced ---------
+# Envoy 1.17 and up disable the V2 api; to use it anyway, run with --bootstrap-version 2, see https://www.envoyproxy.io/docs/envoy/latest/faq/api/transition
+
+## 2021 Jan
+#ENVOYARGS=--bootstrap-version 2
+#APISUFFIX=
+#SIGSCI=4.15.0
+#ENVOY=v1.17.0
+
+#---------- Envoy V2 ---------
+# Leave ENVOYARGS and APISUFFIX blank for V2
 ## 2020 Dec
 #SIGSCI=4.15.0
 #ENVOY=v1.16.2
@@ -62,6 +73,9 @@ AGENT_SCALE = 1
 #SigSci agent 3.15.1 clusters should only have one cluster container
 #AGENT_SCALE = 3
 
+# pass environment variable to docker-compose
+export APISUFFIX
+
 build:
 	docker-compose build --build-arg ENVOY=$(ENVOY) --build-arg SIGSCI=$(SIGSCI) --build-arg ENVOYARGS="$(ENVOYARGS)"
 
@@ -80,6 +94,7 @@ log:
 
 check: test
 test:
+	if docker-compose ps | grep Exit; then echo 'Something broke!'; exit 1; fi
 	@echo "Example fetch from service 1"
 	curl -v localhost:8000/service/1
 	@echo "Example fetch from service 2"

--- a/README.md
+++ b/README.md
@@ -26,3 +26,25 @@ make test
 
 ## Clean up thoroughly
 make clean
+
+# Debugging
+
+If something goes wrong (e.g. you have edited one of the .yaml files poorly) and 'make test' hangs, you can try fetching directly from each of the listeners in the system as follows.
+In order from upstream to downstream:
+```
+$ docker exec envoy-front-proxy-sigsci_service2_1 curl http://localhost:8080/service/1
+$ docker exec envoy-front-proxy-sigsci_service2_1 curl http://localhost:80/service/1
+$ docker exec envoy-front-proxy-sigsci_front-envoy_1 curl http://localhost:80/service/1
+$ curl http://localhost:8000/service/1
+```
+
+Here's what "make start" does, again from upstream to downstream:
+
+Dockerfile-service is run twice; each instance runs start_service.sh,
+- service.py, which serves a message on its localhost:8080/service/1 and localhost:8080/service/2
+- envoy with service-envoy.yaml, which listens on port 80 and forwards requests to the above service on port 8080.
+
+Dockerfile-frontenvoy runs envoy with front-envoy.yaml, which:
+- has an ingress listener on its port 80, and routes /service/1 and /service/2 to port 80 of the two instances of service.
+
+docker-compose.yml listens on your workstation's port 8000 and forwards that to the ingress listener's port 80.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile-frontenvoy
     volumes:
-      - ./front-envoy.yaml:/etc/front-envoy.yaml
+      - ./front-envoy${APISUFFIX}.yaml:/etc/front-envoy.yaml
     networks:
       - envoymesh
     expose:
@@ -21,7 +21,7 @@ services:
       context: .
       dockerfile: Dockerfile-service
     volumes:
-      - ./service-envoy.yaml:/etc/service-envoy.yaml
+      - ./service-envoy${APISUFFIX}.yaml:/etc/service-envoy.yaml
     networks:
       envoymesh:
         aliases:
@@ -36,7 +36,7 @@ services:
       context: .
       dockerfile: Dockerfile-service
     volumes:
-      - ./service-envoy.yaml:/etc/service-envoy.yaml
+      - ./service-envoy${APISUFFIX}.yaml:/etc/service-envoy.yaml
     networks:
       envoymesh:
         aliases:
@@ -48,7 +48,8 @@ services:
   sigsci-agent:
     build:
       context: .
-      dockerfile: Dockerfile-sigsci-agent-grpc
+      #dockerfile: Dockerfile-sigsci-agent-grpc   # if you prefer ubuntu
+      dockerfile: Dockerfile-sigsci-agent-grpc-alpine
     networks:
       envoymesh:
         aliases:

--- a/front-envoy-v3.yaml
+++ b/front-envoy-v3.yaml
@@ -1,5 +1,8 @@
-# This is from envoy 1.9.1's front-proxy example,
-# https://github.com/envoyproxy/envoy/blob/3e25a90a3655f78ef6a95a49feba4cd4370cc408/examples/front-proxy/front-envoy.yaml
+# This is from envoy 1.17's front-proxy example,
+# https://github.com/envoyproxy/envoy/blob/1dd8c12faad8095fc667e9740e7a154f65e24f01/examples/front-proxy/front-envoy.yaml
+# minus the https listener from
+# https://github.com/envoyproxy/envoy/commit/8920bcc681e97b0b4a63fc62d2cf969d8eba96e2
+# and a few port number changes (marked with orig: ) to match the old version
 # plus three sigsci-specific sections, see below.
 
 static_resources:
@@ -7,11 +10,12 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 80  # orig: 8000
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
-        config:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
@@ -30,12 +34,13 @@ static_resources:
                 route:
                   cluster: service2
           ## begin sigsci part 1 ##
-          #the access_log section below is not needed if using SigSci agent 3.15.0
           access_log:
-          - name: envoy.http_grpc_access_log
-            config:
+          - name: envoy.access_loggers.http_grpc
+            typed_config:
+              "@type":  type.googleapis.com/envoy.extensions.access_loggers.grpc.v3.HttpGrpcAccessLogConfig
               common_config:
                 log_name: "sigsci-agent-grpc"
+                transport_api_version: v3
                 grpc_service:
                   envoy_grpc:
                     cluster_name: sigsci-agent-grpc1
@@ -58,7 +63,8 @@ static_resources:
           http_filters:
           ## begin sigsci part 2 ##
           - name: envoy.lua
-            config:
+            typed_config:
+              "@type":  "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
               inline_code: |
                 -- Add an internal :body header to pass the body if <= 8KB
                 function envoy_on_request(req)
@@ -72,35 +78,47 @@ static_resources:
                     req:headers():add(":body", reqbody)
                   end
                 end
-          - name: envoy.ext_authz
-            config:
+          - name: envoy.filters.http.ext_authz
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+              transport_api_version: v3
               grpc_service:
                 envoy_grpc:
                   cluster_name: sigsci-agent-grpc1
                 timeout: 5.2s
               failure_mode_allow: true
           ## end sigsci part 2 ##
-          - name: envoy.router
-            config: {}
+          - name: envoy.filters.http.router
+            typed_config: {}
   clusters:
   - name: service1
     connect_timeout: 0.25s
     type: strict_dns
     lb_policy: round_robin
     http2_protocol_options: {}
-    hosts:
-    - socket_address:
-        address: service1
-        port_value: 80
+    load_assignment:
+      cluster_name: service1
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: service1
+                port_value: 80  # orig: 8000
   - name: service2
     connect_timeout: 0.25s
     type: strict_dns
     lb_policy: round_robin
     http2_protocol_options: {}
-    hosts:
-    - socket_address:
-        address: service2
-        port_value: 80
+    load_assignment:
+      cluster_name: service2
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: service2
+                port_value: 80  # orig: 8000
   ## begin sigsci part 3 ##
   - name: sigsci-agent-grpc1
     connect_timeout: 0.25s
@@ -108,14 +126,31 @@ static_resources:
     lb_policy: round_robin
     http2_protocol_options: {}
     #tls_context: {}
-    hosts:
-    - socket_address:
-        address: sigsci-agent-grpc
-        port_value: 8000
+    load_assignment:
+      cluster_name: sigsci-agent-grpc1
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: sigsci-agent-grpc
+                port_value: 8000
   ## end sigsci part 3 ##
+
 admin:
   access_log_path: "/dev/null"
   address:
     socket_address:
       address: 0.0.0.0
       port_value: 8001
+layered_runtime:
+  layers:
+    - name: static_layer_0
+      static_layer:
+        envoy:
+          resource_limits:
+            listener:
+              example_listener_name:
+                connection_limit: 10000
+        overload:
+          global_downstream_max_connections: 50000

--- a/service-envoy-v3.yaml
+++ b/service-envoy-v3.yaml
@@ -1,0 +1,59 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/service"
+                route:
+                  cluster: local_service
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config: {}
+
+  clusters:
+  - name: local_service
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: some_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8080
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8081
+layered_runtime:
+  layers:
+    - name: static_layer_0
+      static_layer:
+        envoy:
+          resource_limits:
+            listener:
+              example_listener_name:
+                connection_limit: 10000
+        overload:
+          global_downstream_max_connections: 50000


### PR DESCRIPTION
Adds -v3.yaml files for envoy 1.17 and up.

v3 support requires sigsci-agent 4.16, released today.